### PR TITLE
New std.math module; implement more math-related functions

### DIFF
--- a/demo/math.nv
+++ b/demo/math.nv
@@ -1,9 +1,32 @@
 module main
 
-import super.std.core
+import super.std.math
 
 let x = 6.sqrt()
-let y = 6.9.sqrt()
+println(x) // 2.44948...
 
-println(x)
-println(y)
+let y = 6.9.sqrt()
+println(y) // 2.62678...
+
+
+let z = 1.clamp(2, 3);
+println(z) // 2
+
+z = 5.clamp(2, 3);
+println(z) // 3
+
+
+let fac = 10.factorial()
+println(fac) // 3628800
+
+
+let gcd = 60.gcd(7)
+println(gcd) // 1
+
+
+let lcm = 69.lcm(5)
+println(lcm) // 345
+
+
+let exp = 6.9.exp()
+println(exp) // 992.23844...

--- a/std/core.nv
+++ b/std/core.nv
@@ -84,55 +84,6 @@ fn extends toResult(self: ?$A, err: $B) -> Result($A, $B) {
     return Result::Err(err)
 }
 
-// math functions
-
-fn extends min(self: Int, other: Int) -> Int {
-    if self < other {
-        return self
-    }
-    return other
-}
-
-fn extends max(self: Int, other: Int) -> Int {
-    if self > other {
-        return self
-    }
-    return other
-}
-
-fn extends abs(self: Int) -> Int {
-    if self < 0 {
-        return -self
-    }
-    return self
-}
-
-fn extends pow(self: Int, other: Int) -> Int {
-    let result = 1
-    for i <- 0; i < other; i += 1 {
-        result = result * self
-    }
-    return result
-}
-
-// approximation method to calculate square root
-// sorry if it's not 100% accurate
-fn extends sqrt(self: Float) -> Float {
-    let x = Cast::float(self).unwrap()
-    let y = (x + 1.0) / 2.0
-
-    while y < x {
-        x = y
-        y = (x + Cast::float(self).unwrap() / x) / 2.0
-    }
-
-    return x
-}
-
-fn extends sqrt(self: Int) -> Float {
-    return Cast::float().unwrap().sqrt()
-}
-
 // basic list functions
 
 fn extends iota(n: Int) -> [Int] {
@@ -171,26 +122,4 @@ fn range(start: Int, end: Int) -> [Int] {
 
 fn range(end: Int) -> [Int] {
     return range(0, end)
-}
-
-fn bin(n: Int) -> String {
-    if n < 0 {
-        return "-" + bin(-n)
-    }
-    let result = ""
-    let i = n
-    while i > 0 {
-        result = Cast::string(i % 2) + result
-        i = i / 2
-    }
-    return result
-}
-
-fn divmod(n: Int, d: Int) -> #(Int, Int) {
-    return #(n / d, n % d)
-}
-
-fn round(n: Float) -> Int {
-    // since its a Float, should be safe to cast
-    return Cast::int(n + 0.5).unwrap()
 }

--- a/std/math.nv
+++ b/std/math.nv
@@ -1,0 +1,128 @@
+module math
+
+fn extends min(self: Int, other: Int) -> Int {
+    if self < other {
+        return self
+    }
+    return other
+}
+
+fn extends max(self: Int, other: Int) -> Int {
+    if self > other {
+        return self
+    }
+    return other
+}
+
+fn extends abs(self: Int) -> Int {
+    if self < 0 {
+        return -self
+    }
+    return self
+}
+
+fn extends pow(self: Int, other: Int) -> Int {
+    let result = 1
+    for i <- 0; i < other; i += 1 {
+        result = result * self
+    }
+    return result
+}
+
+// approximation method to calculate square root
+// sorry if it's not 100% accurate
+fn extends sqrt(self: Float) -> Float {
+    let x = Cast::float(self).unwrap()
+    let y = (x + 1.0) / 2.0
+
+    while y < x {
+        x = y
+        y = (x + Cast::float(self).unwrap() / x) / 2.0
+    }
+
+    return x
+}
+
+fn extends sqrt(self: Int) -> Float {
+    return Cast::float().unwrap().sqrt()
+}
+
+// limit a value between a minimum and a maximum value
+fn extends clamp(self: Int, min: Int, max: Int) -> Int {
+    if self < min {
+        return min
+    }
+    
+    if self > max {
+        return max
+    }
+
+    return self
+}
+
+// calculate the factorial of a number
+fn extends factorial(self: Int) -> Int {
+    let result = 1
+
+    for i <- 2; i <= self; i += 1 {
+        result = result * i
+    }
+
+    return result
+}
+
+// calculate the greatest common divisor
+fn extends gcd(self: Int, other: Int) -> Int {
+    let a = self.abs()
+    let b = other.abs()
+
+    while b != 0 {
+        let temp = b
+        b = a % b
+        a = temp
+    }
+
+    return a
+}
+
+// calculate the least common multiple
+fn extends lcm(self: Int, other: Int) -> Int {
+    return (self * other).abs() / self.gcd(other)
+}
+
+// exponentiate a floating point number
+// it uses approximation so don't rely on this for
+// precise results
+fn extends exp(self: Float) -> Float {
+    let result = 1.0
+    let term = 1.0
+
+    for n <- 1.0; n < 20.0; n += 1.0 {
+        term = term * self / n
+        result = result + term
+    }
+
+    return result
+}
+
+fn bin(n: Int) -> String {
+    if n < 0 {
+        return "-" + bin(-n)
+    }
+    let result = ""
+    let i = n
+    while i > 0 {
+        result = Cast::string(i % 2) + result
+        i = i / 2
+    }
+    return result
+}
+
+fn divmod(n: Int, d: Int) -> #(Int, Int) {
+    return #(n / d, n % d)
+}
+
+fn round(n: Float) -> Int {
+    // since its a Float, should be safe to cast
+    return Cast::int(n + 0.5).unwrap()
+}


### PR DESCRIPTION
This PR moves all the math-related functions from `std.core` to a new `std.math` module. It also brings new functions, such as:
- `clamp`: clamp an `Int` value between a minimum and a maximum
- `factorial`: calculate the factorial of an `Int`
- `gcd`: calculate the greatest common divisor of an `Int` and another given number
- `lcm`: calculate the least common multiple of an `Int` and another given number
- `exp`: exponentiate a floating point number. This function uses an approximation, so the results aren't 100% accurate

Hopefully this PR will be of use for the avid mathematicians. ;)